### PR TITLE
Fixed the module import in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "butler-blocks",
   "version": "1.0.3",
   "description": "Butler Labs Inc.'s Library of embeddable components and apis to power AI for developers",
-  "main": "lib/butlerBlocks.js",
-  "module": "lib/butlerBlocks.js",
+  "main": "dist/butlerBlocks.js",
+  "module": "dist/butlerBlocks.js",
   "types": "lib/butlerBlocks.d.ts",
   "files": [
     "lib",


### PR DESCRIPTION
We actually want to serve distributed bundles instead of typescript compiled code. So lib directory will only serve the typescript declaration from now.